### PR TITLE
Fix variable assignments for AnimatedEvent test

### DIFF
--- a/Modules/AnimatedEvent.py
+++ b/Modules/AnimatedEvent.py
@@ -107,10 +107,10 @@ def create_lens_animation(M: float,
 
 # Test the function if this script is run directly
 if __name__ == "__main__":
-    M=10,  # Stellar-mass black hole
-    mu=5,  # Proper motion in mas/yr
-    Dl=2,  # Lens distance in kpc
-    Ds=8,  # Source distance in kpc
+    M = 10  # Stellar-mass black hole
+    mu = 5  # Proper motion in mas/yr
+    Dl = 2  # Lens distance in kpc
+    Ds = 8  # Source distance in kpc
     create_lens_animation(
         M,
         mu,


### PR DESCRIPTION
## Summary
- use float assignments for M, mu, Dl and Ds in `Modules/AnimatedEvent.py`

## Testing
- `pytest -q`
- `python Modules/AnimatedEvent.py`

------
https://chatgpt.com/codex/tasks/task_e_686467fd5dc883289f04f22f848b41e3