### PR TITLE
Fix percentage variable for empty checklists

### DIFF
--- a/Modules/Checklist.py
+++ b/Modules/Checklist.py
@@ -167,7 +167,7 @@ class Checklist:
             checked_count = sum(checkbox.value for checkbox in checkboxes)
             progress.value = checked_count
             if len(checkboxes) == 0:
-                percentage_label.value = f"100%"
+                percentage = 100
             else:
                 percentage = (checked_count / len(checkboxes)) * 100
             percentage_label.value = f"{percentage:.0f}%"


### PR DESCRIPTION
## Summary
- handle case where exercise checklist has zero items in `update_progress`

## Testing
- `python -m py_compile Modules/Checklist.py`

------
https://chatgpt.com/codex/tasks/task_e_6864681a6dd48328b9f68a0b86646377