### PR TITLE
Remove conda environment prefix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,4 +28,3 @@ dependencies:
       - MulensModel
       - VBMicrolensing
 
-prefix: /opt/anaconda3/envs/TheGuide


### PR DESCRIPTION
## Summary
- remove the `prefix` entry from `environment.yml`

## Testing
- `conda env create -f environment.yml -n testenv` *(fails: `conda` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864681e919c8328902339b365ad42dc