### PR TITLE
Add CI and basic tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -v

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,0 +1,38 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+import os
+import tempfile
+
+import Modules.AnimatedEvent as AnimatedEvent
+import Modules.Checklist as Checklist
+import Modules.Guide as Guide
+import Modules.PDF as PDF
+
+
+def test_pdf_repr():
+    pdf = PDF.PDF('example.pdf')
+    assert 'example.pdf' in pdf._repr_html_()
+
+
+def test_guide_list_entries():
+    entries = Guide.list_entries(print_list=False)
+    assert isinstance(entries, list)
+    assert len(entries) > 0
+
+
+def test_checklist_list_notebooks():
+    # Should not raise exceptions and should print available notebooks
+    Checklist.Checklist.list_notebooks()
+
+
+def test_animated_event(tmp_path):
+    output_name = 'test.gif'
+    AnimatedEvent.create_lens_animation(
+        M=1.0,
+        mu=1.0,
+        Dl=1.0,
+        Ds=2.0,
+        output_file=output_name,
+        save_path=str(tmp_path) + '/'  # path must end with /
+    )
+    assert (tmp_path / output_name).exists()


### PR DESCRIPTION
## Summary
- add tests to import each module and exercise simple functions
- run tests with GitHub Actions on pushes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646c93dbc48328b99465de6209739f