### PR TITLE
Fix README env placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ To embark on your microlensing adventure, simply follow these straightforward st
 1. Create a dedicated environment with the required dependencies:
     ```bash
     sudo apt-get install python3-venv
-    python3 -m venv .*environment-name*
-    source *environment-name*/bin/activate
+    python3 -m venv <env-name>
+    source <env-name>/bin/activate
     pip install -r requirements.txt
     ```
     for pip users on macOS or Linux,


### PR DESCRIPTION
## Summary
- clarify the environment creation and activation placeholders in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68646ca68b0c8328b8d35eadd463939b